### PR TITLE
 update list.join example to work correctly

### DIFF
--- a/R/list.join.R
+++ b/R/list.join.R
@@ -16,7 +16,7 @@
 #'        p3=list(name="Jenny",age=20))
 #' l2 <- list(p1=list(name="Jenny",age=20,type="A"),
 #'        p2=list(name="Ken",age=20,type="B"),
-#'        p3=list(name="James",age=21,type="A"))
+#'        p3=list(name="James",age=22,type="A"))
 #' list.join(l1,l2,name)
 #' list.join(l1,l2,.[c("name","age")])
 #' }


### PR DESCRIPTION
when I tried to perform the `list.join` docs example 2, I got error

```
list.join(l1,l2,.["name","age"])
 Error in .["name", "age"] : incorrect number of dimensions
```

I believe this should be instead as it is in this [`list.join` tests](https://github.com/renkun-ken/rlist/blob/master/tests/testthat/test-list.join.R#L13).

```
list.join(l1,l2,.[c("name","age")])
```

To test that this multi-key example is working I changed the data to have James `age = 22` to show that `age` and `name` must match for `list.join` to return.
