### PR TITLE
add/fix test for list.search on nested list

### DIFF
--- a/tests/testthat/test-list.search.R
+++ b/tests/testthat/test-list.search.R
@@ -71,16 +71,12 @@ test_that("list.search", {
     )
     , list( "aa", "bb" )
   )
-  #list.search returns blank names
-  #don't know how to specify inline without pipeR
-  #so do in two steps here
-  res_emptyname <- structure(list(list(df=list(letter="a")),list("aa")))
-  names(res_emptyname) <- c("","")
   
-
+  #list.search returns blank names
+  #might want to revisit
   expect_identical(
     list.search(y, .[equal("a", pattern=T)], "character")
-    ,res_emptyname
+    ,structure(list(list(df=list(letter="a")),list("aa")),names=c("",""))
   )
 
 })


### PR DESCRIPTION
handle empty names in list returned by `list.search` as mentioned in #42 and fix test to use `expect_identical` now since comparing lists instead of vectors

let me know if you want a separate pull for `master`
